### PR TITLE
feat: use organization-level CODE_REVIEW_ANTHROPIC_API_KEY secret

### DIFF
--- a/.github/workflows/code-review-label.yml
+++ b/.github/workflows/code-review-label.yml
@@ -18,9 +18,6 @@ on:
         required: false
         type: string
         default: ''
-    secrets:
-      ANTHROPIC_API_KEY:
-        required: true
 
 jobs:
   check-label:
@@ -73,8 +70,6 @@ jobs:
     uses: ./.github/workflows/code-review.yml
     with:
       ignore_patterns: ${{ inputs.ignore_patterns }}
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
   remove-label:
     needs: [check-label, call-code-review]

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -8,9 +8,6 @@ on:
         required: false
         type: string
         default: ''
-    secrets:
-      ANTHROPIC_API_KEY:
-        required: true
 
 jobs:
   code-review:
@@ -70,7 +67,7 @@ jobs:
           # Copy the generated review to expected location
           cp .claude/tmp/review.md claude-review.md
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.CODE_REVIEW_ANTHROPIC_API_KEY }}
 
       - name: Comment PR with Claude Code Review
         if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Summary
- Remove ANTHROPIC_API_KEY from workflow_call secrets in both code review workflows
- Update code-review.yml to use secrets.CODE_REVIEW_ANTHROPIC_API_KEY organization secret
- Simplify workflow usage by eliminating need for consumers to pass API key as parameter

## Changes
- **code-review.yml**: Removed workflow input secret requirement and updated environment variable
- **code-review-label.yml**: Removed workflow input secret requirement and secret passing

## Benefits
- Workflows now automatically use the organization-level secret
- Consumers no longer need to provide the API key when using these workflows
- Cleaner workflow interface and better security practices

🤖 Generated with [Claude Code](https://claude.ai/code)